### PR TITLE
Gave names to our behaviors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0.0a2 (unreleased)
 --------------------
 
+- Gave names to our behaviors: ``collective.classifiers.themes`` and ``collective.classifiers.categories``.
+  [maurits]
+
 - Tested on Plone 5.2 and 6.0 with all supported Python versions.
   This includes Plone 5.2 on Python 2.7.
   [maurits]

--- a/collective/classifiers/configure.zcml
+++ b/collective/classifiers/configure.zcml
@@ -55,12 +55,14 @@
   <adapter name="classifiers_categories" factory=".indexers.classifiers_categories" />
 
   <plone:behavior
+      name="collective.classifiers.themes"
       title="Themes classifiers"
       description="Adds classifiers_themes field."
       provides=".behaviors.IThemes"
       for="plone.dexterity.interfaces.IDexterityContent"
       />
   <plone:behavior
+      name="collective.classifiers.categories"
       title="Categories classifiers"
       description="Adds classifiers_categories field."
       provides=".behaviors.ICategories"

--- a/collective/classifiers/profiles/testfixture/types/TestContainer.xml
+++ b/collective/classifiers/profiles/testfixture/types/TestContainer.xml
@@ -11,8 +11,8 @@
  <property name="behaviors">
   <element value="plone.app.content.interfaces.INameFromTitle"/>
   <element value="plone.app.dexterity.behaviors.metadata.IDublinCore"/>
-  <element value="collective.classifiers.behaviors.IThemes"/>
-  <element value="collective.classifiers.behaviors.ICategories"/>
+  <element value="collective.classifiers.themes"/>
+  <element value="collective.classifiers.categories"/>
  </property>
  <!-- A schema (or model or model_source) is required.
       We only need a basically empty schema. -->


### PR DESCRIPTION
`collective.classifiers.themes` and `collective.classifiers.categories`

Names may become required in Plone 6.