### PR TITLE
Setup code-analysis with gh-actions and docker.

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,0 +1,50 @@
+name: Code Analysis
+on:
+  push:
+
+jobs:
+  code-analysis:
+    name: Code analysis
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v2
+
+      - name: Run check isort
+        uses: plone/code-analysis-action@v1
+        with:
+          check: 'isort'
+          path: |
+            plone
+            setup.py
+
+      - name: Run check black
+        uses: plone/code-analysis-action@v1
+        with:
+          check: 'black'
+          path: |
+            plone
+            setup.py
+
+      - name: Run check flake8
+        uses: plone/code-analysis-action@v1
+        with:
+          check: 'flake8'
+          path: |
+            plone
+            setup.py
+
+      - name: Run check pyroma
+        uses: plone/code-analysis-action@v1
+        with:
+          check: 'pyroma'
+          path: |
+            ./
+
+      - name: Run check zpretty
+        uses: plone/code-analysis-action@v1
+        with:
+          check: 'zpretty'
+          path: |
+            plone

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+### Defensive settings for make:
+#     https://tech.davis-hansson.com/p/make/
+SHELL:=bash
+.ONESHELL:
+.SHELLFLAGS:=-xeu -o pipefail -O inherit_errexit -c
+.SILENT:
+.DELETE_ON_ERROR:
+MAKEFLAGS+=--warn-undefined-variables
+MAKEFLAGS+=--no-builtin-rules
+
+# We like colors
+# From: https://coderwall.com/p/izxssa/colored-makefile-for-golang-projects
+RED=`tput setaf 1`
+GREEN=`tput setaf 2`
+RESET=`tput sgr0`
+YELLOW=`tput setaf 3`
+
+CODE_QUALITY_VERSION=1.0.1
+LINT=docker run --rm -v "$(PWD)":/github/workspace plone/code-quality:${CODE_QUALITY_VERSION} check
+FORMAT=docker run --rm -v "$(PWD)":/github/workspace plone/code-quality:${CODE_QUALITY_VERSION} format
+
+PACKAGE_NAME=collective.classifiers
+PACKAGE_PATH=collective/
+CHECK_PATH=setup.py $(PACKAGE_PATH)
+
+# Add the following 'help' target to your Makefile
+# And add help text after each target name starting with '\#\#'
+.PHONY: help
+help: ## This help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: format
+format:  ## Format the codebase according to our standards
+	$(FORMAT) "$(CHECK_PATH)"
+
+.PHONY: lint
+lint:  ## validate with isort, black, flake8, pyroma, zpretty
+    # Would be nice to have a way to run all available checks, instead of specifying them here.
+	$(LINT) isort "$(CHECK_PATH)"
+	$(LINT) black "$(CHECK_PATH)"
+	$(LINT) flake8 "$(CHECK_PATH)"
+	$(LINT) pyroma .
+	$(LINT) zpretty "$(PACKAGE_PATH)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.isort]
+profile = "black"
+force_alphabetical_sort = true
+force_single_line = true
+lines_after_imports = 2
+
+[tool.flakeheaven.plugins]
+mccabe = ["+*"]
+pycodestyle = ["+*"]
+pyflakes = ["+*"]
+pylint = ["+*"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,8 @@
 [check-manifest]
 ignore =
     *.cfg
+    Makefile
+    pyproject.toml
     requirements.txt
     tox.ini
 


### PR DESCRIPTION
Usage: `make format` and `make lint`.

Problem: zpretty changes `profiles/testfixture/registry.xml` in wrong ways:

- It changes some non-ascii characters.
- It changes an `<element>` with one space into a newline plus some spaces.
  This gives a validation error because a TextLine cannot contain a newline.

```
diff --git a/collective/classifiers/profiles/testfixture/registry.xml b/collective/classifiers/profiles/testfixture/registry.xml
index 47f2341..1818094 100644
--- a/collective/classifiers/profiles/testfixture/registry.xml
+++ b/collective/classifiers/profiles/testfixture/registry.xml
@@ -10,13 +10,13 @@
       </element>
       <element key="Air">
         <element>Quality</element>
-        <element>Non-ascii: 汉语/漢語 Hànyǔ</element>
+        <element>Non-ascii: 汉语/漢語 Hnyǔ</element>
         <element>PAK</element>
         <element>Heavy metals</element>
         <element>Ozon</element>
       </element>
       <element key="汉语">
-        <element>Non-ascii: 汉语/漢語 Hànyǔ</element>
+        <element>Non-ascii: 汉语/漢語 Hnyǔ</element>
         <element>abc</element>
         <element>123</element>
       </element>
@@ -24,17 +24,19 @@
   </record>
   <record name="collective.classifiers.categories">
     <value purge="false">
-        <!-- This space intentionally left blank. -->
+      <!-- This space intentionally left blank. -->
       <element key="Product" />
       <element key="Report">
         <element>Management</element>
         <element>Technical</element>
         <!-- This space intentionally left blank. -->
-        <element> </element>
+        <element>
+        </element>
       </element>
       <element key="汉语/漢語 Hànyǔ">
         <!-- This space intentionally left blank. -->
-        <element> </element>
+        <element>
+        </element>
       </element>
     </value>
   </record>
```